### PR TITLE
I think this is better for testing

### DIFF
--- a/lib/stump/stub.rb
+++ b/lib/stump/stub.rb
@@ -11,7 +11,7 @@ class Object
   #    my_string.retreat!    # => "run away!  run away!"
   #
   def stub!(method_name, options = {}, &stubbed)
-    behavior = (block_given? ? stubbed : proc { return options[:return] })
+    behavior = (block_given? ? stubbed : lambda { return options[:return] })
 
     class << self
       self


### PR DESCRIPTION
Runs the defined method as a block (e.g. closes over local testing variables) instead of in the context of the receiver.

``` ruby
describe "Login form" do
  tests LoginController
  # ...

  it 'should submit with good data' do
    login_button = @controller.loginButton
    # ... assign all valid data to the form ...
    @submitted = false
    @controller.stub!(:submit) do |email, password|
      @submitted = true
    end
    tap login_button
    @submitted.should == true
  end
end
```
