### PR TITLE
Increase Bacon::Counter when a mock is created

### DIFF
--- a/lib/stump/mocks.rb
+++ b/lib/stump/mocks.rb
@@ -8,6 +8,7 @@ module Stump
 
       def add(mock)
         @mocks ||= []
+        Bacon::Counter[:requirements] += 1
         @mocks << mock
       end
       


### PR DESCRIPTION
This prevents `empty_specification` errors when your spec is only `mock!` calls, and displays the correct requirement count in the final test output
