### PR TITLE
Clear stubs after each examples

### DIFF
--- a/lib/motion/stump_spec_helper.rb
+++ b/lib/motion/stump_spec_helper.rb
@@ -21,6 +21,7 @@ module Stump
 
       def it_with_mock_verification(description, &block)
         @after << proc { verify_mocks }
+        @after << proc { Stump::Stubs.clear! }
         it_without_mock_verification(description, &block)
       end
     end

--- a/lib/stump/stub.rb
+++ b/lib/stump/stub.rb
@@ -11,6 +11,8 @@ class Object
   #    my_string.retreat!    # => "run away!  run away!"
   #
   def stub!(method_name, options = {}, &stubbed)
+    Stump::Stubs.add(self, method_name)
+
     behavior = (block_given? ? stubbed : lambda { return options[:return] })
 
     safe_meta_def method_name, &behavior

--- a/lib/stump/stubs.rb
+++ b/lib/stump/stubs.rb
@@ -1,0 +1,19 @@
+module Stump
+  class Stubs
+    class << self
+      def add(object, method)
+        stubs << [object, method]
+      end
+
+      def stubs
+        @stubs ||= []
+      end
+
+      def clear!
+        stubs.each do |object, method|
+          object.reset(method)
+        end
+      end
+    end
+  end
+end

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -209,5 +209,23 @@ describe "Application 'stump-test'" do
         alias_method :flunk, :original_flunk
       end
     end
+
+    describe "clear stubs" do
+      context "with stub" do
+        before do
+          Dog.stub!(:kind, return: 'Foo')
+        end
+
+        it "runs with stubs" do
+          Dog.kind.should == 'Foo'
+        end
+      end
+
+      context "without stub" do
+        it "runs without stubs" do
+          Dog.kind.should == 'Mammal'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Current stubs are not reset automatically, so they remains after example contexts.
This PR add a hook to reset all stubs after each examples.